### PR TITLE
Make artist name and uri null aware

### DIFF
--- a/lib/models/artist.dart
+++ b/lib/models/artist.dart
@@ -6,8 +6,8 @@ part 'artist.g.dart';
 class Artist {
   Artist(this.name, this.uri);
 
-  final String name;
-  final String uri;
+  final String? name;
+  final String? uri;
 
   factory Artist.fromJson(Map<String, dynamic> json) => _$ArtistFromJson(json);
 


### PR DESCRIPTION
These fields will be null in the case of a podcast being played instead of a regular song.